### PR TITLE
팔로워 목록 조회 API 추가

### DIFF
--- a/src/apis/follows/__init__.py
+++ b/src/apis/follows/__init__.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, status
 
-from src.apis.follows.handler import create_follow_user
-from src.apis.follows.schema import CreateFollowResponse
+from src.apis.follows.handler import create_follow_user, get_follower_list
+from src.apis.follows.schema import CreateFollowResponse, GetFollowListResponse
 
 follow_router = APIRouter(prefix="/follows", tags=["follows"])
 
@@ -11,4 +11,12 @@ follow_router.add_api_route(
     endpoint=create_follow_user.handler,
     response_model=CreateFollowResponse,
     status_code=status.HTTP_201_CREATED,
+)
+
+follow_router.add_api_route(
+    methods=["GET"],
+    path="/follower",
+    endpoint=get_follower_list.handler,
+    response_model=GetFollowListResponse,
+    status_code=status.HTTP_200_OK,
 )

--- a/src/apis/follows/handler/get_follower_list.py
+++ b/src/apis/follows/handler/get_follower_list.py
@@ -1,0 +1,30 @@
+import uuid
+from typing import List
+
+from fastapi import Depends, HTTPException
+
+from src.apis.follows.schema import GetFollowListResponse
+from src.apis.follows.service import FollowService
+from src.apis.users.service import UserService
+from src.models.user import User
+from src.security import get_authorization_header
+
+
+async def handler(
+    access_token: str = Depends(get_authorization_header),
+    user_service: UserService = Depends(),
+    follow_service: FollowService = Depends(),
+) -> GetFollowListResponse:
+    user_id: str = await user_service.decode_jwt(access_token)
+    user: User | None = await user_service.get_user_by_id(user_id)
+
+    follower_list: List[uuid.UUID] = await follow_service.get_follower_list(
+        user_id=user.id
+    )
+
+    print(follower_list)
+
+    if not follower_list:
+        raise HTTPException(status_code=404, detail="follower not found")
+
+    return GetFollowListResponse(follower_list=follower_list)

--- a/src/apis/follows/schema.py
+++ b/src/apis/follows/schema.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import List
 
 from pydantic import BaseModel
 
@@ -10,3 +11,7 @@ class CreateFollowRequest(BaseModel):
 class CreateFollowResponse(BaseModel):
     followee_id: uuid.UUID
     follower_id: uuid.UUID
+
+
+class GetFollowListResponse(BaseModel):
+    follower_list: List[uuid.UUID]

--- a/src/apis/follows/service.py
+++ b/src/apis/follows/service.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import Annotated
 
 from fastapi import Depends
+from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from src.apis.dependencies import get_session
@@ -27,3 +28,16 @@ class FollowService:
         await self.session.refresh(follow)
 
         return follow
+
+    async def get_follower_list(self, user_id: uuid.UUID) -> list[uuid.UUID]:
+        follows = await self.session.exec(
+            select(Follow).where(Follow.followee_id == user_id)
+        )
+
+        print(follows, "SAdsadfafasd")
+
+        follower_list: list[uuid.UUID] = []
+        for follow in follows:
+            follower_list.append(follow.follower_id)
+
+        return follower_list

--- a/tests/apis/__init__.py
+++ b/tests/apis/__init__.py
@@ -7,7 +7,7 @@ from src.models.user import User
 async def create_user_and_get_jwt(session: AsyncSession) -> dict:
     user = User(
         email="test@gmail.com",
-        password="test1234",
+        password="<PASSWORD>",
         username="user_name",
     )
     session.add(user)

--- a/tests/apis/follows/test_get_followers.py
+++ b/tests/apis/follows/test_get_followers.py
@@ -1,0 +1,71 @@
+import asyncio
+
+import pytest
+from fastapi import status
+from httpx import AsyncClient
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from src.models.follow import Follow
+from src.models.user import User
+from tests.apis import create_user_and_get_jwt
+
+
+@pytest.mark.asyncio
+async def test_get_followers(client: AsyncClient, session: AsyncSession):
+    headers: dict = await create_user_and_get_jwt(session)
+
+    user_list = [
+        User.create(
+            email=f"<EMAIL{i}>",
+            password=f"<PASSWORD{i}>",
+            username=f"test{i}",
+        )
+        for i in range(10)
+    ]
+
+    session.add_all(user_list)
+    await session.commit()
+
+    refresh_task = set()
+    for user in user_list:
+        task = asyncio.create_task(session.refresh(user))
+        refresh_task.add(task)
+    await asyncio.gather(*refresh_task)
+
+    user = await session.exec(select(User).where(User.email == "test@gmail.com"))
+
+    user = user.first()
+
+    followers = [
+        Follow(follower_id=follower.id, followee_id=user.id) for follower in user_list
+    ]
+
+    session.add_all(followers)
+    await session.commit()
+
+    for follow in followers:
+        await session.refresh(follow)
+
+    response = await client.get(
+        "/follows/follower",
+        headers=headers,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.json()["follower_list"]) == 10
+    for follow in followers:
+        assert str(follow.follower_id) in response.json()["follower_list"]
+
+
+@pytest.mark.asyncio
+async def test_get_followers_not_follow(client: AsyncClient, session: AsyncSession):
+    headers: dict = await create_user_and_get_jwt(session)
+
+    response = await client.get(
+        "/follows/follower",
+        headers=headers,
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {"detail": "follower not found"}


### PR DESCRIPTION
- [feat] 팔로워 목록 조회 API: 특정 사용자의 팔로워 목록을 가져오는 API 엔드포인트를 구현했습니다.
- [test] 팔로워 목록 조회 API: 새로운 API의 기능을 검증하기 위한 테스트 케이스를 추가했습니다. 이 테스트는 API가 예상된 팔로워 데이터를 정확히 반환하는지 확인합니다.