### PR TITLE
팔로잉 목록 조회 API 추가

### DIFF
--- a/src/apis/follows/__init__.py
+++ b/src/apis/follows/__init__.py
@@ -1,7 +1,15 @@
 from fastapi import APIRouter, status
 
-from src.apis.follows.handler import create_follow_user, get_follower_list
-from src.apis.follows.schema import CreateFollowResponse, GetFollowListResponse
+from src.apis.follows.handler import (
+    create_follow_user,
+    get_follower_list,
+    get_following_list,
+)
+from src.apis.follows.schema import (
+    CreateFollowResponse,
+    GetFollowingListResponse,
+    GetFollowListResponse,
+)
 
 follow_router = APIRouter(prefix="/follows", tags=["follows"])
 
@@ -18,5 +26,13 @@ follow_router.add_api_route(
     path="/follower",
     endpoint=get_follower_list.handler,
     response_model=GetFollowListResponse,
+    status_code=status.HTTP_200_OK,
+)
+
+follow_router.add_api_route(
+    methods=["GET"],
+    path="/following",
+    endpoint=get_following_list.handler,
+    response_model=GetFollowingListResponse,
     status_code=status.HTTP_200_OK,
 )

--- a/src/apis/follows/handler/get_following_list.py
+++ b/src/apis/follows/handler/get_following_list.py
@@ -3,7 +3,7 @@ from typing import List
 
 from fastapi import Depends, HTTPException
 
-from src.apis.follows.schema import GetFollowListResponse
+from src.apis.follows.schema import GetFollowingListResponse
 from src.apis.follows.service import FollowService
 from src.apis.users.service import UserService
 from src.models.user import User
@@ -14,15 +14,15 @@ async def handler(
     access_token: str = Depends(get_authorization_header),
     user_service: UserService = Depends(),
     follow_service: FollowService = Depends(),
-) -> GetFollowListResponse:
+) -> GetFollowingListResponse:
     user_id: str = await user_service.decode_jwt(access_token)
     user: User | None = await user_service.get_user_by_id(user_id)
 
-    follower_list: List[uuid.UUID] = await follow_service.get_follower_list(
+    following_list: List[uuid.UUID] = await follow_service.get_following_list(
         user_id=user.id
     )
 
-    if not follower_list:
+    if not following_list:
         raise HTTPException(status_code=404, detail="follower not found")
 
-    return GetFollowListResponse(follower_list=follower_list)
+    return GetFollowingListResponse(following_list=following_list)

--- a/src/apis/follows/schema.py
+++ b/src/apis/follows/schema.py
@@ -15,3 +15,7 @@ class CreateFollowResponse(BaseModel):
 
 class GetFollowListResponse(BaseModel):
     follower_list: List[uuid.UUID]
+
+
+class GetFollowingListResponse(BaseModel):
+    following_list: List[uuid.UUID]

--- a/src/apis/follows/service.py
+++ b/src/apis/follows/service.py
@@ -34,10 +34,15 @@ class FollowService:
             select(Follow).where(Follow.followee_id == user_id)
         )
 
-        print(follows, "SAdsadfafasd")
-
-        follower_list: list[uuid.UUID] = []
-        for follow in follows:
-            follower_list.append(follow.follower_id)
+        follower_list: list[uuid.UUID] = [follow.follower_id for follow in follows]
 
         return follower_list
+
+    async def get_following_list(self, user_id: uuid.UUID) -> list[uuid.UUID]:
+        follows = await self.session.exec(
+            select(Follow).where(Follow.follower_id == user_id)
+        )
+
+        following_list: list[uuid.UUID] = [follow.followee_id for follow in follows]
+
+        return following_list

--- a/tests/apis/follows/test_get_following.py
+++ b/tests/apis/follows/test_get_following.py
@@ -1,0 +1,58 @@
+import asyncio
+
+import pytest
+from fastapi import status
+from httpx import AsyncClient
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from src.models.follow import Follow
+from src.models.user import User
+from tests.apis import create_user_and_get_jwt
+
+
+@pytest.mark.asyncio
+async def test_get_following(client: AsyncClient, session: AsyncSession):
+    headers: dict = await create_user_and_get_jwt(session)
+
+    user_list = [
+        User.create(
+            email=f"<EMAIL{i}>",
+            password=f"<PASSWORD{i}>",
+            username=f"test{i}",
+        )
+        for i in range(10)
+    ]
+
+    session.add_all(user_list)
+    await session.commit()
+
+    refresh_task = set()
+    for user in user_list:
+        task = asyncio.create_task(session.refresh(user))
+        refresh_task.add(task)
+    await asyncio.gather(*refresh_task)
+
+    user = await session.exec(select(User).where(User.email == "test@gmail.com"))
+
+    user = user.first()
+
+    followers = [
+        Follow(follower_id=user.id, followee_id=follower.id) for follower in user_list
+    ]
+
+    session.add_all(followers)
+    await session.commit()
+
+    for follow in followers:
+        await session.refresh(follow)
+
+    response = await client.get(
+        "/follows/following",
+        headers=headers,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.json()["following_list"]) == 10
+    for follow in followers:
+        assert str(follow.followee_id) in response.json()["following_list"]


### PR DESCRIPTION
- [feat] 팔로잉 목록 조회 API: 특정 사용자가 팔로우하고 있는 사용자의 목록을 가져오는 API 엔드포인트를 구현했습니다.
- [test] 팔로잉 목록 조회 API: 새로운 API의 기능을 검증하기 위한 테스트 케이스를 추가했습니다. 이 테스트는 API가 예상된 팔로잉 데이터를 정확히 반환하는지 확인합니다.