### PR TITLE
팔로잉 사용자 게시물 가져오기 API 구현 및 수정

### DIFF
--- a/src/apis/posts/__init__.py
+++ b/src/apis/posts/__init__.py
@@ -1,6 +1,8 @@
+from typing import List
+
 from fastapi import APIRouter, status
 
-from src.apis.posts.handler import create_post, get_post, get_posts
+from src.apis.posts.handler import create_post, get_following_posts, get_post, get_posts
 from src.apis.posts.schema import CreatePostResponse, GetPostResponse
 
 post_router = APIRouter(prefix="/posts", tags=["posts"])
@@ -16,7 +18,15 @@ post_router.add_api_route(
     methods=["GET"],
     path="",
     endpoint=get_posts.handler,
-    response_model=list[GetPostResponse],
+    response_model=List[GetPostResponse],
+    status_code=status.HTTP_200_OK,
+)
+
+post_router.add_api_route(
+    methods=["GET"],
+    path="/following",
+    endpoint=get_following_posts.handler,
+    response_model=List[GetPostResponse],
     status_code=status.HTTP_200_OK,
 )
 

--- a/src/apis/posts/handler/get_following_posts.py
+++ b/src/apis/posts/handler/get_following_posts.py
@@ -1,0 +1,33 @@
+from typing import List
+
+from fastapi import Depends, HTTPException
+
+from src.apis.posts.schema import GetPostResponse
+from src.apis.posts.service import PostService
+from src.apis.users.service import UserService
+from src.models.user import User
+from src.security import get_authorization_header
+
+
+async def handler(
+    access_token: str = Depends(get_authorization_header),
+    user_service: UserService = Depends(),
+    post_service: PostService = Depends(),
+) -> List[GetPostResponse]:
+    user_id: str = await user_service.decode_jwt(access_token)
+    user: User | None = await user_service.get_user_by_id(user_id)
+
+    post_list = await post_service.get_following_post(user_id=user.id)
+
+    if not post_list:
+        raise HTTPException(status_code=404, detail="Post not found")
+
+    return [
+        GetPostResponse(
+            id=post.id,
+            contents=post.contents,
+            writer=post.writer,
+            created_at=post.created_at,
+        )
+        for post in post_list
+    ]

--- a/src/apis/posts/handler/get_post.py
+++ b/src/apis/posts/handler/get_post.py
@@ -21,5 +21,6 @@ async def handler(
     return GetPostResponse(
         id=post.id,
         contents=post.contents,
+        writer=post.writer,
         created_at=post.created_at,
     )

--- a/src/apis/posts/handler/get_posts.py
+++ b/src/apis/posts/handler/get_posts.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from fastapi import Depends
 
 from src.apis.posts.schema import GetPostResponse
@@ -11,7 +13,7 @@ async def handler(
     access_token: str = Depends(get_authorization_header),
     user_service: UserService = Depends(),
     post_service: PostService = Depends(),
-) -> list[GetPostResponse]:
+) -> List[GetPostResponse]:
     user_id: str = await user_service.decode_jwt(access_token)
     user: User | None = await user_service.get_user_by_id(user_id)
     posts = await post_service.get_user_posts(user_id=user.id)
@@ -20,7 +22,7 @@ async def handler(
             id=post.id,
             contents=post.contents,
             created_at=post.created_at,
-            updated_at=post.updated_at,
+            writer=post.writer,
         )
         for post in posts
     ]

--- a/src/apis/posts/schema.py
+++ b/src/apis/posts/schema.py
@@ -1,4 +1,5 @@
 import datetime
+import uuid
 
 from pydantic import BaseModel, Field
 
@@ -16,4 +17,5 @@ class CreatePostResponse(BaseModel):
 class GetPostResponse(BaseModel):
     id: int
     contents: str
+    writer: uuid.UUID
     created_at: datetime.datetime

--- a/tests/apis/posts/test_get_following_posts.py
+++ b/tests/apis/posts/test_get_following_posts.py
@@ -1,0 +1,66 @@
+import pytest
+from httpx import AsyncClient
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from src.models.follow import Follow
+from src.models.post import Post
+from src.models.user import User
+from tests.apis import create_user_and_get_jwt
+
+
+@pytest.mark.asyncio
+async def test_get_following_posts(client: AsyncClient, session: AsyncSession):
+    headers: dict = await create_user_and_get_jwt(session)
+
+    user_list = [
+        User.create(
+            email=f"<EMAIL{i}>",
+            password=f"<PASSWORD{i}>",
+            username=f"test{i}",
+        )
+        for i in range(10)
+    ]
+
+    session.add_all(user_list)
+    await session.commit()
+
+    for user in user_list:
+        await session.refresh(user)
+
+    user = await session.exec(select(User).where(User.email == "test@gmail.com"))
+
+    user = user.first()
+
+    user_id = str(user.id)
+
+    followers = [
+        Follow(follower_id=user.id, followee_id=followee.id) for followee in user_list
+    ]
+
+    session.add_all(followers)
+
+    posts = [
+        Post(contents=f"{writer.id} test{i}", writer=writer.id)
+        for writer in user_list
+        for i in range(5)
+    ]
+
+    user_ids = [str(user.id) for user in user_list]
+
+    session.add_all(posts)
+    await session.commit()
+
+    for follow in followers:
+        await session.refresh(follow)
+
+    for post in posts:
+        await session.refresh(post)
+
+    response = await client.get(f"/posts/following", headers=headers)
+
+    assert response.status_code == 200
+    assert len(response.json()) == 50
+    for post in response.json():
+        assert post["writer"] in user_ids
+        assert post["writer"] != user_id

--- a/tests/apis/posts/test_get_post.py
+++ b/tests/apis/posts/test_get_post.py
@@ -42,6 +42,7 @@ async def test_get_post_successfully(client: AsyncClient, session: AsyncSession)
     assert data == {
         "id": post.id,
         "contents": post.contents,
+        "writer": str(post.writer),
         "created_at": post.created_at.isoformat(),
     }
 

--- a/tests/apis/posts/test_get_posts.py
+++ b/tests/apis/posts/test_get_posts.py
@@ -51,6 +51,7 @@ async def test_get_posts_successfully(client: AsyncClient, session: AsyncSession
         {
             "id": post_2.id,
             "contents": post_2.contents,
+            "writer": str(post_2.writer),
             "created_at": post_2.created_at.isoformat(),
         }
     ]


### PR DESCRIPTION
- [feat] 팔로잉 사용자 게시물 가져오기 API: 특정 사용자가 팔로우한 사용자들의 게시물을 가져오는 API 엔드포인트를 구현했습니다.
- [fix] GetPostResponse writer 컬럼 업데이트: GetPostResponse에서 writer 컬럼을 수정하여 데이터가 올바르게 반환되도록 했습니다.
- [test] 팔로잉 사용자 게시물 API 테스트: 새로운 API의 기능을 검증하기 위한 테스트 케이스를 추가했습니다. 이 테스트는 API가 예상된 팔로잉 사용자들의 게시물을 정확히 반환하는지 확인합니다