### PR TITLE
팔로워 게시물 캐시 업데이트 및 백그라운드 작업 처리

### DIFF
--- a/src/apis/posts/handler/create_post.py
+++ b/src/apis/posts/handler/create_post.py
@@ -1,5 +1,9 @@
+import uuid
+from typing import List
+
 from fastapi import Depends
 
+from src.apis.follows.service import FollowService
 from src.apis.posts.schema import CreatePostRequest, CreatePostResponse
 from src.apis.posts.service import PostService
 from src.apis.users.service import UserService
@@ -11,11 +15,16 @@ async def handler(
     request: CreatePostRequest,
     access_token: str = Depends(get_authorization_header),
     user_service: UserService = Depends(),
+    follow_service: FollowService = Depends(),
     post_service: PostService = Depends(),
 ) -> CreatePostResponse:
     user_id: str = await user_service.decode_jwt(access_token)
     user: User | None = await user_service.get_user_by_id(user_id)
     post = await post_service.create_new_post(request=request, user_id=user.id)
+    followers_id: List[uuid.UUID] = await follow_service.get_follower_list(
+        uuid.UUID(user_id)
+    )
+    post_service.add_caching_follower_posts_list(post, followers_id)
 
     return CreatePostResponse(
         id=post.id, contents=post.contents, created_at=post.created_at

--- a/tests/apis/posts/test_create_post.py
+++ b/tests/apis/posts/test_create_post.py
@@ -3,9 +3,13 @@ import datetime
 import pytest
 from fastapi import status
 from httpx import AsyncClient
+from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from src.apis.users.service import UserService
+from src.models.follow import Follow
 from src.models.post import Post
+from src.models.user import User
 from tests.apis import create_user_and_get_jwt
 
 
@@ -78,3 +82,68 @@ async def test_create_post_failed_by_content_validation(
 
     # then
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_create_post_follower_posts_update(
+    client: AsyncClient, session: AsyncSession
+):
+    headers = await create_user_and_get_jwt(session)
+
+    user = (
+        await session.exec(select(User).where(User.email == "test@gmail.com"))
+    ).first()
+    user_id = user.id
+
+    follow_user = User.create(
+        email="<EMAIL>12",
+        password="<PASSWORD>",
+        username="test",
+    )
+
+    session.add(follow_user)
+    await session.commit()
+    await session.refresh(follow_user)
+
+    follower_user_id = follow_user.id
+
+    follow = Follow(
+        followee_id=user_id,
+        follower_id=follower_user_id,
+    )
+
+    session.add(follow)
+    await session.commit()
+
+    for i in range(10):
+        session.add(Post(contents=f"contents{i}", writer=user_id))
+    await session.commit()
+
+    user_service = UserService(session)
+    jwt = await user_service.create_jwt(follower_user_id)
+
+    follow_user_headers = {"Authorization": f"Bearer {jwt}"}
+
+    follow_user_response = await client.get(
+        f"/posts/following", headers=follow_user_headers
+    )
+
+    assert follow_user_response.status_code == status.HTTP_200_OK
+
+    response = await client.post(
+        "/posts",
+        json={
+            "contents": "fan out content",
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+
+    follow_user_response = await client.get(
+        f"/posts/following", headers=follow_user_headers
+    )
+
+    assert follow_user_response.status_code == status.HTTP_200_OK
+    assert len(follow_user_response.json()) == 11
+    assert follow_user_response.json()[0]["contents"] == "fan out content"


### PR DESCRIPTION
- [feat] 팔로워 게시물 캐시 업데이트: 게시글이 등록될 때, 해당 사용자를 팔로우하는 모든 사용자들의 캐시에 게시글 ID를 추가하는 기능을 구현했습니다.
- [test] 팔로워 게시물 캐시 업데이트 테스트: 캐시 업데이트 기능이 정상적으로 동작하는지 확인하기 위한 테스트 케이스를 추가했습니다.
- [feat] 캐시 업데이트 백그라운드 작업 처리: 팔로워 수가 많을 경우, 캐시 업데이트가 오래 걸릴 수 있어 이를 백그라운드 작업으로 처리하도록 개선했습니다.